### PR TITLE
[codex] Manage themes with context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,18 @@ import Layout from "./components/Layout/Layout";
 import PortfolioNavigation from "./components/PortfolioNavigation";
 import SummaryBlock from "./components/SummaryBlock";
 import UtilityInfoBlock from "./components/UtilityInfoBlock";
-import useAppContext from "./context/useAppContext";
 import HelperTextBlock from "./components/HelpTextBlock";
 import CurrentGameLocationTextBlock from "./components/CurrentGameLocationTextBlock";
+import useTheme from "./context/useTheme";
 
 function App() {
-  const context = useAppContext();
+  const { theme } = useTheme();
+
   return (
     <div className="App">
-      <Layout theme={context.theme}>
+      <Layout>
         <div className="max-h-[530px] pause-menu-block relative">
-          {context.theme === 'ff8-theme' && <HelperTextBlock />}
+          {theme === 'ff8-theme' && <HelperTextBlock />}
           <PortfolioNavigation />
           <SummaryBlock />
           <UtilityInfoBlock />

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,3 +1,46 @@
 .headerDark{
   /* background-color: #101724; */
 }
+
+.themeSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid rgb(255 255 255 / 0.6);
+  border-radius: 6px;
+}
+
+.themeOption {
+  position: relative;
+}
+
+.themeInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.themeLabel {
+  display: block;
+  min-width: 3rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 4px;
+  text-align: center;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.themeInput:checked + .themeLabel {
+  background: rgb(255 255 255 / 0.9);
+  color: #111724;
+}
+
+.themeInput:focus-visible + .themeLabel {
+  outline: 2px solid #00ced1;
+  outline-offset: 2px;
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,22 +1,46 @@
 import styles from './Header.module.css';
 import useAppContext from '../../context/useAppContext';
 import { useId } from 'react';
+import type { Theme } from '../../context/ThemeContext';
+import useTheme from '../../context/useTheme';
+
+const themeOptions: { label: string; value: Theme }[] = [
+	{ label: 'FF7', value: 'ff7-theme' },
+	{ label: 'FF8', value: 'ff8-theme' },
+];
 
 const Header = () => {
-	const { siteName, theme, toggleTheme } = useAppContext();
+	const { siteName } = useAppContext();
+	const { theme, setTheme } = useTheme();
 	const id = useId();
-	const ff7Id = `${id}-ff7-theme`;
-	const ff8Id = `${id}-ff8-theme`;
 
 	return (
 		<header className={styles.headerDark}>
 			<div className="flex items-center justify-between">
 				<h1 className="text-4xl">{siteName}</h1>
 
-				<input id={ff7Id} type="radio" name="theme" value="ff7-theme" checked={theme === 'ff7-theme'} onChange={toggleTheme}
-				/> <label htmlFor={ff7Id}>FF7 Theme</label>
-				<input id={ff8Id} type="radio" name="theme" value="ff8-theme" checked={theme === 'ff8-theme'} onChange={toggleTheme}
-				/> <label htmlFor={ff8Id}>FF8 Theme</label>
+				<fieldset className={styles.themeSwitch} aria-label="Theme">
+					{themeOptions.map((option) => {
+						const optionId = `${id}-${option.value}`;
+
+						return (
+							<div className={styles.themeOption} key={option.value}>
+								<input
+									className={styles.themeInput}
+									id={optionId}
+									type="radio"
+									name="theme"
+									value={option.value}
+									checked={theme === option.value}
+									onChange={() => setTheme(option.value)}
+								/>
+								<label className={styles.themeLabel} htmlFor={optionId}>
+									{option.label}
+								</label>
+							</div>
+						);
+					})}
+				</fieldset>
 			</div>
 		</header>
 	);

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,16 +1,17 @@
 
 import type { ReactNode } from "react";
-import type { Theme } from "../../context/AppContext";
+import useTheme from "../../context/useTheme";
 import Footer from "../Footer/Footer";
 import Header from "../Header/Header";
 
 type LayoutProps = {
 	children: ReactNode;
-	theme: Theme;
 };
 
-const Layout = ({ children, theme }: LayoutProps) => {
-	return <div className={`${theme ? theme : "default-theme"} container sm:h-screen mx-auto px-8 pt-8`} >
+const Layout = ({ children }: LayoutProps) => {
+	const { theme } = useTheme();
+
+	return <div className={`${theme} container sm:h-screen mx-auto px-8 pt-8`} >
 		<Header />
 		{children}
 		<Footer />

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,7 +1,5 @@
-import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useMemo, useState } from 'react';
 import useContants from '../hooks/useConstants';
-
-export type Theme = 'ff7-theme' | 'ff8-theme' | 'default-theme';
 
 export type Layout = 'wide' | 'boxed';
 
@@ -14,10 +12,6 @@ export type MenuItem = {
 };
 
 export type AppContextType = {
-	theme: Theme;
-	toggleTheme: () => void;
-	// setTheme accepts either a Theme or an updater function (like React setState)
-	setTheme: (t: Theme | ((prev: Theme) => Theme)) => void;
 	layout: Layout;
 	setLayout: (l: Layout) => void;
 	siteName: string;
@@ -34,42 +28,7 @@ export default AppContext;
 export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 	const { siteName, profileLinks, portfolioLinks } = useContants();
 
-	const [theme, setTheme] = useState<Theme>(() => {
-		if (typeof window === 'undefined') return 'default-theme';
-		const stored = window.localStorage.getItem('app:theme') as Theme | null;
-		if (stored === 'ff7-theme' || stored === 'ff8-theme') return stored;
-		// default to prefers-color-scheme
-		const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false;
-		return prefersDark ? 'ff8-theme' : 'ff7-theme';
-	});
-
 	const [layout, setLayout] = useState<Layout>('wide');
-
-	const setThemeAndPersist = useCallback((t: Theme | ((prev: Theme) => Theme)) => {
-		setTheme((prev) => {
-			const newTheme = typeof t === 'function' ? (t as (p: Theme) => Theme)(prev) : t;
-			try {
-				window.localStorage.setItem('app:theme', newTheme);
-			} catch {
-				// ignore write errors
-			}
-			return newTheme;
-		});
-	}, []);
-
-	const toggleTheme = useCallback(() => {
-		setThemeAndPersist((t) => (t === 'ff7-theme' ? 'ff8-theme' : 'ff7-theme'));
-	}, [setThemeAndPersist]);
-
-	// apply theme class on documentElement
-	useEffect(() => {
-		if (typeof document === 'undefined') return;
-		const body = document.body;
-		if (theme === 'ff7-theme') body.classList.add('ff7-theme');
-		else body.classList.remove('ff7-theme');
-		if (theme === 'ff8-theme') body.classList.add('ff8-theme');
-		else body.classList.remove('ff8-theme');
-	}, [theme]);
 
 	const [focusedMenuItem, setFocusedMenuItemState] = useState<MenuItem | undefined>(undefined);
 
@@ -79,8 +38,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 	}, []);
 
 	const value = useMemo(
-		() => ({ theme, toggleTheme, setTheme: setThemeAndPersist, layout, setLayout, siteName, profileLinks, portfolioLinks, setFocusedMenuItem, focusedMenuItem }),
-		[theme, toggleTheme, setThemeAndPersist, layout, siteName, profileLinks, portfolioLinks, setFocusedMenuItem, focusedMenuItem],
+		() => ({ layout, setLayout, siteName, profileLinks, portfolioLinks, setFocusedMenuItem, focusedMenuItem }),
+		[layout, siteName, profileLinks, portfolioLinks, setFocusedMenuItem, focusedMenuItem],
 	);
 
 	return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,70 @@
+import {
+	createContext,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	type ReactNode,
+} from 'react';
+
+export type Theme = 'ff7-theme' | 'ff8-theme';
+
+type ThemeContextType = {
+	theme: Theme;
+	setTheme: (theme: Theme) => void;
+	toggleTheme: () => void;
+};
+
+const THEME_STORAGE_KEY = 'app:theme';
+const themes: Theme[] = ['ff7-theme', 'ff8-theme'];
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export default ThemeContext;
+
+const isTheme = (value: string | null): value is Theme => {
+	return value === 'ff7-theme' || value === 'ff8-theme';
+};
+
+const getInitialTheme = (): Theme => {
+	if (typeof window === 'undefined') return 'ff7-theme';
+
+	const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+	if (isTheme(storedTheme)) return storedTheme;
+
+	const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false;
+	return prefersDark ? 'ff8-theme' : 'ff7-theme';
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+	const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+	const setTheme = useCallback((nextTheme: Theme) => {
+		setThemeState(nextTheme);
+		window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+	}, []);
+
+	const toggleTheme = useCallback(() => {
+		setThemeState((currentTheme) => {
+			const nextTheme = currentTheme === 'ff7-theme' ? 'ff8-theme' : 'ff7-theme';
+			window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+			return nextTheme;
+		});
+	}, []);
+
+	useEffect(() => {
+		document.body.classList.remove(...themes);
+		document.body.classList.add(theme);
+	}, [theme]);
+
+	const value = useMemo(
+		() => ({
+			theme,
+			setTheme,
+			toggleTheme,
+		}),
+		[theme, setTheme, toggleTheme],
+	);
+
+	return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};

--- a/src/context/useTheme.ts
+++ b/src/context/useTheme.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import ThemeContext from './ThemeContext';
+
+export default function useTheme() {
+	const context = useContext(ThemeContext);
+	if (!context) throw new Error('useTheme must be used within ThemeProvider');
+	return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,14 +3,17 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './styles/index.css'
 import { AppProvider } from './context/AppContext'
+import { ThemeProvider } from './context/ThemeContext'
 
 const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Root element not found');
 
 createRoot(rootElement).render(
   <StrictMode>
-    <AppProvider>
-      <App />
-    </AppProvider>
+    <ThemeProvider>
+      <AppProvider>
+        <App />
+      </AppProvider>
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Add a dedicated ThemeContext and useTheme hook for portfolio theme state
- Wrap the app in ThemeProvider and move theme consumption into App, Layout, and Header
- Replace the header theme controls with an accessible segmented radio group

## Validation
- yarn lint
- yarn build
- Browser check: verified FF7/FF8 switching updates checked state and body theme class

## Notes
- Existing uncommitted UtilityInfoBlock.tsx change was intentionally left out of this PR.